### PR TITLE
Refactor Command.{Parse,Reply}: now driven by declarative configurations.

### DIFF
--- a/architecture/protocol.go
+++ b/architecture/protocol.go
@@ -170,176 +170,32 @@ func (command *Command) Parse(rawCommand string) (bool, error) {
 }
 
 func (command *Command) Reply() (bool, string) {
-
-	//- "BAD_FORMAT\r\n" The client sent a command line that was not well-formed.
-	//   This can happen if the line does not end with \r\n, if non-numeric
-	//   characters occur where an integer is expected, if the wrong number of
-	//   arguments are present, or if the command line is mal-formed in any other
-	//   way.
-	//
-	// - "UNKNOWN_COMMAND\r\n" The client sent a command that the server does not
-	//   know.
-	// TODO
-	// - "OUT_OF_MEMORY\r\n" The server cannot allocate enough memory for the job.
-	//   The client should try again later.
-	//
-	// - "INTERNAL_ERROR\r\n" This indicates a bug in the server. It should never
-	//   happen. If it does happen, please report it at
-	//   http://groups.google.com/group/beanstalk-talk.
-	switch command.Name {
-	case USE:
-		if command.Err == nil {
-			return false, "USING " + command.Params["tube"]
-		}
-	case PUT:
-
-		// 	 - "INSERTED <id>\r\n" to indicate success.
-		//
-		//	 - <id> is the integer id of the new job
-		// TODO
-		//	 - "BURIED <id>\r\n" if the server ran out of memory trying to grow the
-		//	   priority queue data structure.
-		//
-		//	   - <id> is the integer id of the new job
-		//
-		//	 - "EXPECTED_CRLF\r\n" The job body must be followed by a CR-LF pair, that is,
-		//	   "\r\n". These two bytes are not counted in the job size given by the client
-		//	   in the put command line.
-		//
-		//	 - "JOB_TOO_BIG\r\n" The client has requested to put a job with a body larger
-		//	   than max-job-size bytes.
-		//
-		//	 - "DRAINING\r\n" This means that the server has been put into "drain mode" and
-		//	   is no longer accepting new jobs. The client should try another server or
-		//	   disconnect and try again later. To put the server in drain mode, send the
-		//	   SIGUSR1 signal to the process.
-
-		if command.Err == nil {
-			return false, "INSERTED " + command.Job.Id()
-		}
-	case WATCH:
-		// WATCHING <count>\r\n
-		if command.Err == nil {
-			return false, "WATCHING " + command.Params["count"]
-		}
-	case IGNORE:
-		// - "WATCHING <count>\r\n" to indicate success.
-		//
-		// - <count> is the integer number of tubes currently in the watch list.
-		//
-		// - "NOT_IGNORED\r\n" if the client attempts to ignore the only tube in its
-		// watch list.
-		if command.Err == nil {
-			return false, "WATCHING " + command.Params["count"]
-		}
-
-	// RESERVE will return a newly-reserved job. If no job is available to be reserved,
-	// beanstalkd will wait to send a response until one becomes available. Once a
-	// job is reserved for the client, the client has limited time to run (TTR) the
-	// job before the job times out. When the job times out, the server will put the
-	// job back into the ready queue. Both the TTR and the actual time left can be
-	// found in response to the stats-job command.
-	//
-	// If more than one job is ready, beanstalkd will choose the one with the
-	// smallest priority value. Within each priority, it will choose the one that
-	// was received first.
-	//
-	// A timeout value of 0 will cause the server to immediately return either a
-	// response or TIMED_OUT.  A positive value of timeout will limit the amount of
-	// time the client will block on the reserve request until a job becomes
-	// available.
-	//
-	// During the TTR of a reserved job, the last second is kept by the server as a
-	// safety margin, during which the client will not be made to wait for another
-	// job. If the client issues a reserve command during the safety margin, or if
-	// the safety margin arrives while the client is waiting on a reserve command,
-	// the server will respond with:
-	//
-	//    DEADLINE_SOON\r\n
-	//
-	// This gives the client a chance to delete or release its reserved job before
-	// the server automatically releases it.
-	//
-	//    TIMED_OUT\r\n
-	//
-	// If a non-negative timeout was specified and the timeout exceeded before a job
-	// became available, or if the client's connection is half-closed, the server
-	// will respond with TIMED_OUT.
-	//
-	// Otherwise, the only other response to this command is a successful reservation
-	// in the form of a text line followed by the job body:
-	//
-	//    RESERVED <id> <bytes>\r\n
-	//    <data>\r\n
-	//
-	// - <id> is the job id -- an integer unique to this job in this instance of
-	//   beanstalkd.
-	//
-	// - <bytes> is an integer indicating the size of the job body, not including
-	//   the trailing "\r\n".
-	//
-	// - <data> is the job body -- a sequence of bytes of length <bytes> from the
-	//   previous line. This is a verbatim copy of the bytes that were originally
-	//   sent to the server in the put command for this job.
-	case RESERVE:
-		if command.Err == nil {
-			if !command.MoreToSend {
-				command.MoreToSend = true
-				return true, fmt.Sprintf("RESERVED %s %d", command.Job.Id(), command.Job.Bytes)
-			} else {
-				return false, command.Job.Data
-			}
-		}
-	case RESERVE_WITH_TIMEOUT:
-		if command.Err == nil {
-			if !command.MoreToSend {
-				command.MoreToSend = true
-				return true, fmt.Sprintf("RESERVED %s %d", command.Job.Id(), command.Job.Bytes)
-			} else {
-				return false, command.Job.Data
-			}
-		}
-	case DELETE:
-		// The client then waits for one line of response, which may be:
-		//
-		// - "DELETED\r\n" to indicate success.
-		//
-		// - "NOT_FOUND\r\n" if the job does not exist or is not either reserved by the
-		// client, ready, or buried. This could happen if the job timed out before the
-		// client sent the delete command.
-		if command.Err == nil {
-			return false, "DELETED"
-		}
-	case RELEASE:
-		// The client expects one line of response, which may be:
-		//
-		// - "RELEASED\r\n" to indicate success.
-		//
-		// - "BURIED\r\n" if the server ran out of memory trying to grow the priority
-		// queue data structure.
-		//
-		// - "NOT_FOUND\r\n" if the job does not exist or is not reserved by the client.
-		if command.Err == nil {
-			return false, "RELEASED"
-		}
-	case BURY:
-		// There are two possible responses:
-		//
-		// - "BURIED\r\n" to indicate success.
-		//
-		// - "NOT_FOUND\r\n" if the job does not exist or is not reserved by the client.
-		if command.Err == nil {
-			return false, "BURIED"
-		}
-	case TOUCH:
-		// There are two possible responses:
-		//
-		// - "TOUCHED\r\n" to indicate success.
-		//
-		// - "NOT_FOUND\r\n" if the job does not exist or is not reserved by the client.
-		if command.Err == nil {
-			return false, "INSERTED " + command.Job.Id()
-		}
+	if err := command.Err; err != nil {
+		return false, err.Error()
 	}
-	return false, command.Err.Error()
+
+	// cmdReplyOptions = cmdParseOptions - RESERVE, RESERVE_WITH_TIMEOUT
+	if opts, ok := cmdReplyOptions[command.Name]; ok {
+		// Take care of everything except PUT, RESERVE, RESERVE_WITH_TIMEOUT, and TOUCH
+		if !opts.UseJobID {
+			// DELETE, RELEASE, BURY
+			if len(opts.Param) == 0 {
+				return false, opts.Message
+			}
+
+			// USE, WATCH, IGNORE
+			return false, strings.Join([]string{opts.Message, command.Params[opts.Param]}, " ")
+		}
+
+		// PUT, TOUCH
+		return false, strings.Join([]string{opts.Message, command.Job.Id()}, " ")
+	}
+
+	// RESERVE, RESERVE_WITH_TIMEOUT
+	if !command.MoreToSend {
+		command.MoreToSend = true
+		return true, fmt.Sprintf("RESERVED %s %d", command.Job.Id(), command.Job.Bytes)
+	}
+
+	return false, command.Job.Data
 }

--- a/architecture/protocol.go
+++ b/architecture/protocol.go
@@ -145,6 +145,7 @@ func (command *Command) Parse(rawCommand string) (bool, error) {
 		}
 
 		// Store command info.  For future logging, maybe?
+		command.Params = map[string]string{}
 		command.RawCommand = rawCommand
 		for i, paramName := range opts.Params {
 			command.Params[paramName] = parts[i+1]

--- a/architecture/protocol_commandfuncs.go
+++ b/architecture/protocol_commandfuncs.go
@@ -1,0 +1,75 @@
+package architecture
+
+type CommandParseOptions struct {
+	ExpectedLength int
+	WaitingForMore bool
+	Params         []string
+	Name           CommandName
+}
+
+var cmdParseOptions map[CommandName]CommandParseOptions
+
+func init() {
+	cmdParseOptions = map[CommandName]CommandParseOptions{
+		USE: CommandParseOptions{
+			Name:           USE,
+			ExpectedLength: 2,
+			WaitingForMore: false,
+			Params:         []string{"id"},
+		},
+		PUT: CommandParseOptions{
+			Name:           PUT,
+			ExpectedLength: 5,
+			WaitingForMore: true,
+			Params:         []string{"pri", "delay", "ttr", "bytes"},
+		},
+		WATCH: CommandParseOptions{
+			Name:           WATCH,
+			ExpectedLength: 2,
+			WaitingForMore: false,
+			Params:         []string{"tube"},
+		},
+		IGNORE: CommandParseOptions{
+			Name:           IGNORE,
+			ExpectedLength: 2,
+			WaitingForMore: false,
+			Params:         []string{"tube"},
+		},
+		RESERVE: CommandParseOptions{
+			Name:           RESERVE,
+			ExpectedLength: 1,
+			WaitingForMore: false,
+			Params:         []string{},
+		},
+		RESERVE_WITH_TIMEOUT: CommandParseOptions{
+			Name:           RESERVE_WITH_TIMEOUT,
+			ExpectedLength: 2,
+			WaitingForMore: false,
+			Params:         []string{"timeout"},
+		},
+		DELETE: CommandParseOptions{
+			Name:           DELETE,
+			ExpectedLength: 2,
+			WaitingForMore: false,
+			Params:         []string{"id"},
+		},
+		RELEASE: CommandParseOptions{
+			Name:           RELEASE,
+			ExpectedLength: 4,
+			WaitingForMore: false,
+			Params:         []string{"id", "pri", "delay"},
+		},
+		BURY: CommandParseOptions{
+			Name:           BURY,
+			ExpectedLength: 2,
+			WaitingForMore: false,
+			Params:         []string{"id", "pri"},
+		},
+		TOUCH: CommandParseOptions{
+			Name:           TOUCH,
+			ExpectedLength: 2,
+			WaitingForMore: false,
+			Params:         []string{"id"},
+		},
+	}
+}

--- a/architecture/protocol_config.go
+++ b/architecture/protocol_config.go
@@ -19,61 +19,61 @@ var cmdReplyOptions map[CommandName]CommandReplyOptions
 
 func init() {
 	cmdParseOptions = map[CommandName]CommandParseOptions{
-		USE: CommandParseOptions{
+		USE: {
 			Name:           USE,
 			ExpectedLength: 2,
 			WaitingForMore: false,
 			Params:         []string{"id"},
 		},
-		PUT: CommandParseOptions{
+		PUT: {
 			Name:           PUT,
 			ExpectedLength: 5,
 			WaitingForMore: true,
 			Params:         []string{"pri", "delay", "ttr", "bytes"},
 		},
-		WATCH: CommandParseOptions{
+		WATCH: {
 			Name:           WATCH,
 			ExpectedLength: 2,
 			WaitingForMore: false,
 			Params:         []string{"tube"},
 		},
-		IGNORE: CommandParseOptions{
+		IGNORE: {
 			Name:           IGNORE,
 			ExpectedLength: 2,
 			WaitingForMore: false,
 			Params:         []string{"tube"},
 		},
-		RESERVE: CommandParseOptions{
+		RESERVE: {
 			Name:           RESERVE,
 			ExpectedLength: 1,
 			WaitingForMore: false,
 			Params:         []string{},
 		},
-		RESERVE_WITH_TIMEOUT: CommandParseOptions{
+		RESERVE_WITH_TIMEOUT: {
 			Name:           RESERVE_WITH_TIMEOUT,
 			ExpectedLength: 2,
 			WaitingForMore: false,
 			Params:         []string{"timeout"},
 		},
-		DELETE: CommandParseOptions{
+		DELETE: {
 			Name:           DELETE,
 			ExpectedLength: 2,
 			WaitingForMore: false,
 			Params:         []string{"id"},
 		},
-		RELEASE: CommandParseOptions{
+		RELEASE: {
 			Name:           RELEASE,
 			ExpectedLength: 4,
 			WaitingForMore: false,
 			Params:         []string{"id", "pri", "delay"},
 		},
-		BURY: CommandParseOptions{
+		BURY: {
 			Name:           BURY,
 			ExpectedLength: 2,
 			WaitingForMore: false,
 			Params:         []string{"id", "pri"},
 		},
-		TOUCH: CommandParseOptions{
+		TOUCH: {
 			Name:           TOUCH,
 			ExpectedLength: 2,
 			WaitingForMore: false,
@@ -82,49 +82,49 @@ func init() {
 	}
 
 	cmdReplyOptions = map[CommandName]CommandReplyOptions{
-		USE: CommandReplyOptions{
+		USE: {
 			Result:   false,
 			Message:  "USING",
 			Param:    "tube",
 			UseJobID: false,
 		},
-		PUT: CommandReplyOptions{
+		PUT: {
 			Result:   false,
 			Message:  "INSERTED",
 			Param:    "",
 			UseJobID: true,
 		},
-		WATCH: CommandReplyOptions{
+		WATCH: {
 			Result:   false,
 			Message:  "WATCHING",
 			Param:    "count",
 			UseJobID: false,
 		},
-		IGNORE: CommandReplyOptions{
+		IGNORE: {
 			Result:   false,
 			Message:  "WATCHING",
 			Param:    "count",
 			UseJobID: false,
 		},
-		DELETE: CommandReplyOptions{
+		DELETE: {
 			Result:   false,
 			Message:  "DELETED",
 			Param:    "",
 			UseJobID: false,
 		},
-		RELEASE: CommandReplyOptions{
+		RELEASE: {
 			Result:   false,
 			Message:  "RELEASED",
 			Param:    "",
 			UseJobID: false,
 		},
-		BURY: CommandReplyOptions{
+		BURY: {
 			Result:   false,
 			Message:  "BURIED",
 			Param:    "",
 			UseJobID: false,
 		},
-		TOUCH: CommandReplyOptions{
+		TOUCH: {
 			Result:   false,
 			Message:  "INSERTED",
 			Param:    "",

--- a/architecture/protocol_config.go
+++ b/architecture/protocol_config.go
@@ -7,7 +7,15 @@ type CommandParseOptions struct {
 	Name           CommandName
 }
 
+type CommandReplyOptions struct {
+	Result   bool
+	Message  string
+	Param    string
+	UseJobID bool
+}
+
 var cmdParseOptions map[CommandName]CommandParseOptions
+var cmdReplyOptions map[CommandName]CommandReplyOptions
 
 func init() {
 	cmdParseOptions = map[CommandName]CommandParseOptions{
@@ -70,6 +78,57 @@ func init() {
 			ExpectedLength: 2,
 			WaitingForMore: false,
 			Params:         []string{"id"},
+		},
+	}
+
+	cmdReplyOptions = map[CommandName]CommandReplyOptions{
+		USE: CommandReplyOptions{
+			Result:   false,
+			Message:  "USING",
+			Param:    "tube",
+			UseJobID: false,
+		},
+		PUT: CommandReplyOptions{
+			Result:   false,
+			Message:  "INSERTED",
+			Param:    "",
+			UseJobID: true,
+		},
+		WATCH: CommandReplyOptions{
+			Result:   false,
+			Message:  "WATCHING",
+			Param:    "count",
+			UseJobID: false,
+		},
+		IGNORE: CommandReplyOptions{
+			Result:   false,
+			Message:  "WATCHING",
+			Param:    "count",
+			UseJobID: false,
+		},
+		DELETE: CommandReplyOptions{
+			Result:   false,
+			Message:  "DELETED",
+			Param:    "",
+			UseJobID: false,
+		},
+		RELEASE: CommandReplyOptions{
+			Result:   false,
+			Message:  "RELEASED",
+			Param:    "",
+			UseJobID: false,
+		},
+		BURY: CommandReplyOptions{
+			Result:   false,
+			Message:  "BURIED",
+			Param:    "",
+			UseJobID: false,
+		},
+		TOUCH: CommandReplyOptions{
+			Result:   false,
+			Message:  "INSERTED",
+			Param:    "",
+			UseJobID: true,
 		},
 	}
 }


### PR DESCRIPTION
Configurations are placed in protocol_config.go.

I was very tempted to define `CommandParseFunc` and `CommandReplyFunc`, then simplify `Parse` and `Reply` to map lookups, but making things declarative allows the protocol to be extended.