### PR TITLE
Adding Build config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,14 +24,16 @@ jobs:
             go get github.com/vimukthi-git/beanstalkg
             go test -v ./... | tee ${TEST_RESULTS}/go-test.out
 
-      - run: docker login -u "vimukthi" -p "vb540@ee"
-      - run:
-          name: Docker build
+      - deploy:
+          name: Conditionally run docker push. i.e if this is a release branch
           command: |
-            CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /beanstalkg .
-            docker build -t "beanstalkg:${CIRCLE_BRANCH}" .
-            docker tag beanstalkg:$CIRCLE_BRANCH beanstalkg/beanstalkg:$CIRCLE_BRANCH
-            docker push beanstalkg/beanstalkg:$CIRCLE_BRANCH
+            release_regex='^v([0-9]+\.){0,2}(\*|[0-9]+)$'
+            if [[ $CIRCLE_BRANCH =~ $release_regex ]]; then
+              curl --user ${CIRCLE_API_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=deploy_docker \
+                --data revision=$CIRCLE_SHA1 \
+                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+            fi
 
       #- run:
           #name: Run integration tests

--- a/.circleci/config_test.yml
+++ b/.circleci/config_test.yml
@@ -1,0 +1,61 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: beanstalkg/beanstalkg_build:v0.03
+
+    working_directory: /go/src/github.com/vimukthi-git/beanstalkg
+
+    environment:
+      TEST_RESULTS: /tmp/test-results
+
+    steps:
+      - checkout
+
+      - run: mkdir -p $TEST_RESULTS
+
+      - run:
+          name: Run unit tests
+          environment:
+            #CONTACTS_DB_URL: "postgres://ubuntu@localhost:5432/contacts?sslmode=disable"
+            #CONTACTS_DB_MIGRATIONS: /go/src/github.com/circleci/cci-demo-go/db/migrations
+          command: |
+            trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
+            go get github.com/vimukthi-git/beanstalkg
+            go test -v ./... | tee ${TEST_RESULTS}/go-test.out
+
+      - run: docker login -u "vimukthi" -p "vb540@ee"
+      - run:
+          name: Docker build
+          command: |
+            CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /beanstalkg .
+            docker build -t "beanstalkg:${CIRCLE_BRANCH}" .
+            docker tag beanstalkg:$CIRCLE_BRANCH beanstalkg/beanstalkg:$CIRCLE_BRANCH
+            docker push beanstalkg/beanstalkg:$CIRCLE_BRANCH
+
+      #- run:
+          #name: Run integration tests
+          #command: |
+
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: raw-test-output
+
+      - store_test_results:
+          path: /tmp/test-results
+
+  deploy_docker:
+    docker:
+      - image: beanstalkg/beanstalkg_build:v0.03
+    working_directory: /go/src/github.com/vimukthi-git/beanstalkg
+    steps:
+      - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - run:
+          name: Docker build
+          command: |
+            CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /beanstalkg .
+            docker build -t "beanstalkg:${CIRCLE_BRANCH}" .
+            docker tag beanstalkg:$CIRCLE_BRANCH beanstalkg/beanstalkg:$CIRCLE_BRANCH
+            docker push beanstalkg/beanstalkg:$CIRCLE_BRANCH
+
+

--- a/.circleci/images/primary/Dockerfile
+++ b/.circleci/images/primary/Dockerfile
@@ -1,0 +1,2 @@
+FROM golang:1.8.0-stretch
+RUN go get github.com/jstemmer/go-junit-report

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
-FROM golang:1.8
-RUN go get -u github.com/vimukthi-git/beanstalkg
-WORKDIR /src/github.com/vimukthi-git/beanstalkg
-COPY . /src/github.com/vimukthi-git/beanstalkg
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /beanstalkg .
-
 FROM centurylink/ca-certs
-COPY --from=0 /beanstalkg /
+ADD beanstalkg /
 EXPOSE 11300
 CMD ["/beanstalkg"]


### PR DESCRIPTION
Added a `circleci` config yml file to automate the build and release process.
In detail,
- Created a new image for building beanstalkg. This will ensure that the build environment is independent of the CI server we use.
- Run tests for all branches.
- Build and push actual beanstalkg image to docker if the current branch is detected as a release branch. i.e has a semantic version name say v1.0.1 