### PR TITLE
fixing the parameter name USE

### DIFF
--- a/architecture/protocol.go
+++ b/architecture/protocol.go
@@ -151,6 +151,7 @@ func (command *Command) Parse(rawCommand string) (bool, error) {
 			command.Params[paramName] = parts[i+1]
 		}
 		command.WaitingForMore = opts.WaitingForMore
+		log.Debug("PROTOCOL command after parsing ", command)
 
 		return !command.WaitingForMore, nil
 	}

--- a/architecture/protocol_config.go
+++ b/architecture/protocol_config.go
@@ -23,7 +23,7 @@ func init() {
 			Name:           USE,
 			ExpectedLength: 2,
 			WaitingForMore: false,
-			Params:         []string{"id"},
+			Params:         []string{"tube"},
 		},
 		PUT: {
 			Name:           PUT,

--- a/operation/tube_register.go
+++ b/operation/tube_register.go
@@ -26,14 +26,14 @@ func NewTubeRegister(
 							createTubeHandler(c.Params["tube"], watchedTubeConnectionsReceiver)
 					}
 					useTubeConnectionReceiver <- tubeChannels[c.Params["tube"]]
-					log.Debug("TUBE_REGISTER sent tube: ", c.Params["tube"])
+					log.Debug("TUBE_REGISTER sent tube for use: ", c.Params["tube"])
 				case architecture.WATCH:
 					if _, ok := tubeChannels[c.Params["tube"]]; !ok {
 						tubeChannels[c.Params["tube"]], tubeStopChannels[c.Params["tube"]] =
 							createTubeHandler(c.Params["tube"], watchedTubeConnectionsReceiver)
 					}
 					useTubeConnectionReceiver <- tubeChannels[c.Params["tube"]]
-					log.Debug("TUBE_REGISTER sent tube: ", c.Params["tube"])
+					log.Debug("TUBE_REGISTER sent tube for watch: ", c.Params["tube"])
 				}
 			// TODO handle commands and send tubeChannels to clients if required
 			case <-stop:


### PR DESCRIPTION
A bug was created in `USE` command because parameter name has been wrong. This causes `USE` not to properly select the tube, resulting in jobs not getting created. Corrected it and added more logging.

@stephenwithav You can make sure commands work by running some of the nodejs scripts in `tests` directory before submitting a pull req. 
For example you can run the producer.js script to add some jobs to the queue once its running in localhost. Then you can check if the jobs are being properly updated by running worker.js. 

But I think we need a proper integration test suite. Which I will create soon.